### PR TITLE
Add CLI Option for AWS Profile

### DIFF
--- a/airmail/bash/ecr_push.sh
+++ b/airmail/bash/ecr_push.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 printf "\n"
 echo "Building to repo: $ECR_REPO"
 echo "Building version: $VERSION"

--- a/airmail/cli.py
+++ b/airmail/cli.py
@@ -62,8 +62,10 @@ class AirMailCLI(click.MultiCommand):
         return mod.cli
 
 @click.command(cls=AirMailCLI, context_settings=CONTEXT_SETTINGS)
+@click.option('-p', '--profile', help='The AWS profile to use')
 @click.option('-e', '--env', help='The environment to target', default=lambda: os.environ.get('ENV', ''))
 @pass_context
-def cli(ctx, env):
+def cli(ctx, profile, env):
     """A CLI for getting code into the cloud"""
     ctx.env = env
+    ctx.profile=profile

--- a/airmail/commands/cmd_ecs.py
+++ b/airmail/commands/cmd_ecs.py
@@ -10,7 +10,7 @@ def cli(ctx):
     if ctx.env is "":
         ctx.env = click.prompt('In which environment would you like to deploy?', type=str)
 
-    ecs_service = ECSService(ctx.env)
+    ecs_service = ECSService(env=ctx.env, profile=ctx.profile)
     ctx.ecs_service = ecs_service
     ctx.add_line_break()
     ctx.preamble_log('Current Env', ecs_service.get_env())

--- a/airmail/services/ecs_service.py
+++ b/airmail/services/ecs_service.py
@@ -15,9 +15,11 @@ class ECSService(DeployFile):
         if profile is None:
             self.client = boto3.client('ecs')
         else:
-            self.client = boto3.session.Session(profile_name=profile);
+            self.session = boto3.session.Session(profile_name=profile)
+            self.client = self.session.client('ecs')
         # The env
         self.env = env
+        self.profile = profile
 
         # Init the Deploy File class
         DeployFile.__init__(self, self.env)
@@ -101,6 +103,9 @@ class ECSService(DeployFile):
             'TASK_IMAGE_TAG': image_tag,
             'APP_DIR': app_dir
         }
+
+        if not self.profile is None:
+            env_dict['AWS_PROFILE'] = self.profile
 
         val = run_script('ecr_push', env_dict) # Returns the exit code from bash
 

--- a/airmail/services/ecs_service.py
+++ b/airmail/services/ecs_service.py
@@ -10,9 +10,12 @@ from airmail.utils.bash import run_script
 from airmail.utils.files import read_package_json_version
 
 class ECSService(DeployFile):
-    def __init__(self, env):
+    def __init__(self, env=None, profile=None):
         # ECS client
-        self.client = boto3.client('ecs')
+        if profile is None:
+            self.client = boto3.client('ecs')
+        else:
+            self.client = boto3.session.Session(profile_name=profile);
         # The env
         self.env = env
 


### PR DESCRIPTION
Adds a CLI option for specifying an AWS profile to utilize.  For example:

```
airmail --profile=foo-bar-baz ecs build-image
```

Will utilize the `foo-bar-baz` profile when interacting with the underlying AWS calls