### PR TITLE
Support Multiple Config Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ A list of commands and corresponding arguments/environment variables [can be fou
 
 Airmail assumes your local env is configured per [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration) configuration. The tool uses Boto3 to execute requests to AWS and does not do anything to setup your local environment.
 
+### Environment Variables
+
+You can use a few environment variables to control how Airmail is run.
+
+- `AWS_PROFILE`: will run the Boto3 commands under the local profile you have configured
+- `AIRMAIL_ENV`: automatically chooses which environment to run commands for. Good for CI/CD so the prompt is not triggered.
+- `AIRMAIL_DRY_RUN`: will run all of the command except the actual call to AWS
+- `AIRMAIL_CONFIG_FILE` _(default: `config.yml`)_: specifies the file to read from in the `.deploy` directory for application configuration. The file must be a valid YAML file.
+- `AIRMAIL_VERBOSE`: will log in verbose mode. Good for debugging.
 
 ## Local Development
 

--- a/airmail/cli.py
+++ b/airmail/cli.py
@@ -69,14 +69,16 @@ class AirMailCLI(click.MultiCommand):
         return mod.cli
 
 @click.command(cls=AirMailCLI, context_settings=CONTEXT_SETTINGS)
-@click.option('-p', '--profile', help='The AWS profile to use', default=lambda: os.environ.get('AWS_PROFILE', None))
-@click.option('-e', '--env', help='The environment to target', default=lambda: os.environ.get('ENV', ''))
-@click.option('-d', '--dry-run', help='Commands run with this flag will not result in actual changes to your AWS configuration', default=lambda: os.environ.get('DRY_RUN', False))
-@click.option('-v', '--verbose', help='Run commands with verbose logging', default=lambda: os.environ.get('VERBOSE', False))
+@click.option("-p", "--profile", help="The AWS profile to use", default=lambda: os.environ.get("AWS_PROFILE", None))
+@click.option("-e", "--env", help="The environment to target", default=lambda: os.environ.get("ENV", ""))
+@click.option("-d", "--dry-run", help="Commands run with this flag will not result in actual changes to your AWS configuration", default=lambda: os.environ.get("DRY_RUN", False))
+@click.option("-c", "--config-file", help="Specify the config file to use when running the commands", default=lambda: os.environ.get("CONFIG_FILE", "config.yml"))
+@click.option("-v", "--verbose", help="Run commands with verbose logging", default=lambda: os.environ.get("VERBOSE", False))
 @pass_context
-def cli(ctx, profile, env, dry_run, verbose):
+def cli(ctx, profile, env, dry_run, config_file, verbose):
     """A CLI for getting code into the cloud"""
     ctx.env = env
     ctx.profile = profile
     ctx.dry_run = bool(dry_run)
     ctx.verbose = bool(verbose)
+    ctx.config_file = config_file

--- a/airmail/commands/cmd_ecs.py
+++ b/airmail/commands/cmd_ecs.py
@@ -14,7 +14,7 @@ def cli(ctx):
     if ctx.env is "":
         ctx.env = click.prompt('In which environment would you like to deploy?', type=str)
 
-    ecs_service = ECSService(env=ctx.env, profile=ctx.profile)
+    ecs_service = ECSService(env=ctx.env, profile=ctx.profile, config=ctx.config_file)
     ctx.ecs_service = ecs_service
     ctx.add_line_break()
     ctx.preamble_log("Current Env", ecs_service.get_env())

--- a/airmail/services/deploy_file.py
+++ b/airmail/services/deploy_file.py
@@ -5,13 +5,16 @@ from pydash import get, set_
 import boto3
 
 class DeployFile():
-    def __init__(self, env):
+    def __init__(self, env, config):
+        # config = config if config is not None else "config.yml"
+
         # Grab cwd
         self.cwd = os.getcwd()
         # Grab file
-        self.file_path = self.cwd + '/.deploy/config.yml'
+        self.file_path = self.cwd + '/.deploy/' + config
         # Read file or throw
         self.deploy_json = read_yml(self.file_path)
+        print('Config file!!!', self.deploy_json)
         # The environment
         self.env = env
 

--- a/airmail/services/deploy_file.py
+++ b/airmail/services/deploy_file.py
@@ -9,7 +9,7 @@ class DeployFile():
         # Grab cwd
         self.cwd = os.getcwd()
         # Grab file
-        self.file_path = self.cwd + '/.deploy/' + config
+        self.file_path = "{cwd}/.deploy/{config}".format(cwd=self.cwd, config=config)
         # Read file or throw
         self.deploy_json = read_yml(self.file_path)
         # The environment
@@ -36,11 +36,12 @@ class DeployFile():
 
     def get_service(self):
         """Get the service name from the config file"""
-        env_service_declaration = get(self.deploy_json, self.env + ".service", False)
+        prop = "{env}.service".format(env=self.env)
+        env_service_declaration = get(self.deploy_json, prop, False)
         return env_service_declaration
 
     def build_image_id(self):
-        image_tag = self.get_top_level_prop('accountID') + '.dkr.ecr.us-east-1.amazonaws.com/' + self.get_with_prefix('name', '/')
+        image_tag = "{tag}.dkr.ecr.us-east-1.amazonaws.com/{name}".format(tag=self.get_top_level_prop('accountID'), name=self.get_with_prefix('name', '/'))
         set_(self.deploy_json, '.imageID', image_tag)
 
     def get_with_prefix(self, prop, delim='-'):

--- a/airmail/services/deploy_file.py
+++ b/airmail/services/deploy_file.py
@@ -6,15 +6,12 @@ import boto3
 
 class DeployFile():
     def __init__(self, env, config):
-        # config = config if config is not None else "config.yml"
-
         # Grab cwd
         self.cwd = os.getcwd()
         # Grab file
         self.file_path = self.cwd + '/.deploy/' + config
         # Read file or throw
         self.deploy_json = read_yml(self.file_path)
-        print('Config file!!!', self.deploy_json)
         # The environment
         self.env = env
 

--- a/airmail/services/ecs_service.py
+++ b/airmail/services/ecs_service.py
@@ -10,7 +10,7 @@ from airmail.utils.bash import run_script
 from airmail.utils.files import read_package_json_version
 
 class ECSService(DeployFile):
-    def __init__(self, env=None, profile=None):
+    def __init__(self, env=None, profile=None, config=None):
         # ECS client
         if profile is None:
             self.client = boto3.client('ecs')
@@ -22,7 +22,7 @@ class ECSService(DeployFile):
         self.profile = profile
 
         # Init the Deploy File class
-        DeployFile.__init__(self, self.env)
+        DeployFile.__init__(self, self.env, config)
 
         self.ServiceConfigBuilder = ServiceConfig(self.get_prop, self.get_top_level_prop, self.get_with_prefix)
         self.TaskConfigBuilder = TaskConfig(self.get_prop, self.get_top_level_prop, self.get_with_prefix)


### PR DESCRIPTION
Resolves #14 

Set `AIRMAIL_CONFIG_FILE` to the name of the file in the `.deploy` to read from.